### PR TITLE
Added argument to allow for `NXDOMAIN` responses

### DIFF
--- a/README.org
+++ b/README.org
@@ -53,15 +53,16 @@ You can include blocker in your CoreDNS just as you would include any other Core
 
 ** Corefile
 
-The =blocker= directive inside Corefile requires two arguments. The first argument is the absolute
+The =blocker= directive inside Corefile requires three arguments. The first argument is the absolute
 path to the blocklist file. The second argument is the frequency at which the blocklist file is
-checked for updates.
+checked for updates. The third is the response type from the plugin, either =empty= for a valid DNS 
+response with 0.0.0.0 or ::6 or =nxdomain= to respond with a DNS empty response.
 
 The frequency is specified as a string and the value should be a valid argument to the
 [[https://pkg.go.dev/time#ParseDuration][time.ParseDuration]] function.
 
 #+begin_src conf
-  blocker /home/user/blocklist_file 1h abp
+  blocker /home/user/blocklist_file 1h abp empty
 #+end_src
 
 This is a sample Corefile including the =blocker= directive. It will block domains that are
@@ -81,7 +82,7 @@ specified in the blocklist and forward everything else to a full DNS server.
 	log . "{common} {/blocker/request-blocked}"
 
 	# blocker blocks domains which are specified in the blocklist
-	blocker /home/user/blocklist_file 1h hosts
+	blocker /home/user/blocklist_file 1h hosts empty
 
 	# forward handles any request that is not blocked by blocker
 	forward . 127.0.0.1:9053

--- a/setup.go
+++ b/setup.go
@@ -8,7 +8,7 @@ import (
 )
 
 const PluginName = "blocker"
-const RequiredArgs = 3
+const RequiredArgs = 4
 
 func init() {
 	plugin.Register(PluginName, setup)
@@ -30,6 +30,11 @@ func setup(c *caddy.Controller) error {
 	blocklistFilePath := args[0]
 	blocklistUpdateFrequency := args[1]
 	blocklistType := args[2]
+	blocklistResponseType := args[3]
+
+	if blocklistResponseType != "empty" && blocklistResponseType != "nxdomain" {
+		return plugin.Error(PluginName, c.ArgErr())
+	}
 
 	logger := clog.NewWithPlugin(PluginName)
 
@@ -45,8 +50,9 @@ func setup(c *caddy.Controller) error {
 	// Add the Plugin to CoreDNS, so Servers can use it in their plugin chain.
 	dnsserver.GetConfig(c).AddPlugin(func(next plugin.Handler) plugin.Handler {
 		return Blocker{
-			Next:    next,
-			Decider: decider,
+			Next:         next,
+			Decider:      decider,
+			ResponseType: blocklistResponseType,
 		}
 	})
 


### PR DESCRIPTION
This patchset adds a argument for the response type:

- `empty` - Responds with the default behavior
- `nxdomain` - Returns a `NXDOMAIN` error and no other data

There's some behavior built into advanced adblocker evasion that will utilize JS prefetch (and some other techniques) to determine if a blocker is in place. Utilizing a `NXDOMAIN` response will break this behavior in some cases and also has slightly different behavior that I think is preferable, such as how some browsers render empty pages.

Here's a quick config example with `nxdomain` and dig response output:

```
 .:5353 {
	metadata

	# log writes 1 line to the log for every DNS request
	# The last word in the log line will be YES if the request was blocked and NO if it was not
	# blocked.
	# This behaviour is supported by the metadata plugin.
	log . "{common} {/blocker/request-blocked}"

	# blocker blocks domains which are specified in the blocklist
	blocker /tmp/unad.hosts 1h hosts nxdomain

	# forward handles any request that is not blocked by blocker
	forward . 1.1.1.1
 }
```

```
$ dig -p 5353 zpu.samsungelectronics.com @127.0.0.1

; <<>> DiG 9.18.19 <<>> -p 5353 zpu.samsungelectronics.com @127.0.0.1
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 9596
;; flags: qr rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1
;; WARNING: recursion requested but not available

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; COOKIE: xxxxxxxxxxxxxxx (echoed)
;; QUESTION SECTION:
;zpu.samsungelectronics.com.	IN	A

;; Query time: 1 msec
;; SERVER: 127.0.0.1#5353(127.0.0.1) (UDP)
;; WHEN: Tue Apr 16 18:22:35 MDT 2024
;; MSG SIZE  rcvd: 67
```

```
$ ./coredns -conf test.conf
[INFO] plugin/blocker: updated blocklist; blocked domains: before: 0, after: 124961; last updated: before: 0001-01-01 00:00:00 +0000 UTC, after: 2024-04-16 18:22:20.716774584 -0600 MDT m=+0.053971151
.:5353
CoreDNS-1.11.2
linux/amd64, go1.21.8, 8de4531d3-dirty
[INFO] 127.0.0.1:48737 - 9596 "A IN zpu.samsungelectronics.com. udp 67 false 1232" NXDOMAIN qr,rd 44 0.000192261s YES
[INFO] 127.0.0.1:46864 - 62164 "A IN zpufakename.samsungelectronics.com. udp 75 false 1232" NXDOMAIN qr,rd,ra 171 0.301954036s NO
```