### PR TITLE
Build coredns binary for multiple architectures and OS

### DIFF
--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -1,0 +1,92 @@
+name: Build Binary
+
+on:
+  push:
+    # Enable after development is completed.
+    # tags:
+    #   - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        go-version: [ '1.22.5' ]
+        os-flavor: [ 'linux' ]
+        architecture: [ 'amd64', 'arm', 'arm64' ]
+        path-to-build: [ './cmd/email-random' ]
+
+    steps:
+      # You can test your matrix by printing the current Go version
+      - name: Display Go version
+        run: go version
+      # Fetch the coredns repository first
+      - name: Fetch the coredns repository at a tag
+        uses: actions/checkout@v4
+        with:
+          repository: 'coredns/coredns'
+          ref: 'v1.11.1'
+      # Fetch this repository first
+      - name: Fetch the present repository
+        uses: actions/checkout@v4
+        with:
+          path: './plugin/blocker'
+      - name: Move plugin.cfg to the top level
+        run: |
+          ls -lsh plugin.cfg
+          head plugin.cfg
+          mv ./plugin/blocker/plugin.cfg ./plugin.cfg
+          ls -lsh plugin.cfg
+          head plugin.cfg
+      - name: Test everything works well
+        run: |
+          ls -lsh coredns
+          ls -lsh coredns/plugin
+          ls -lsh coredns/plugin/blocker/
+      # Caching is enabled by default when using setup-go
+      - name: Setup Go ${{ matrix.go-version }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Generate plugin configuration based things and make binary
+        run: |
+          OUTPUT_FILE_NAME="./$(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }}"
+          go generate
+          make BINARY=$OUTPUT_FILE_NAME
+          file ./$OUTPUT_FILE_NAME
+      # - name: Build binary for the given paths
+      #   id: build-binary
+      #   run: |
+      #     echo "Ref: ${{ github.ref }}; Commit: $GITHUB_SHA"
+
+      #     OUTPUT_FILE_NAME="./$(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }}"
+
+      #     GOOS=${{ matrix.os-flavor }} GOARCH=${{ matrix.architecture }} \
+      #       go build \
+      #       -ldflags="-X \"github.com/icyflame/kindle-my-clippings-parser/internal/env.Version=${{ github.ref }} $GITHUB_SHA\"" \
+      #       -o $OUTPUT_FILE_NAME ${{ matrix.path-to-build }}
+
+      #     sha256sum $OUTPUT_FILE_NAME > $OUTPUT_FILE_NAME.checksum
+
+      #     file ./$OUTPUT_FILE_NAME
+      #     file ./$OUTPUT_FILE_NAME.checksum
+
+      #     chmod 755 ./$OUTPUT_FILE_NAME
+      #     chmod 644 ./$OUTPUT_FILE_NAME.checksum
+
+      #     tar --create --gzip --file ./$OUTPUT_FILE_NAME.tar.gz ./$OUTPUT_FILE_NAME ./$OUTPUT_FILE_NAME.checksum
+
+      #     ls -lsh .
+
+      #     {
+      #         echo 'OUTPUT_FILES<<EOF'
+      #         echo $OUTPUT_FILE_NAME.tar.gz
+      #         echo EOF
+      #     } >> "$GITHUB_OUTPUT"
+      # - name: Upload binaries if a tag was pushed
+      #   uses: softprops/action-gh-release@v2
+      #   if: startsWith(github.ref, 'refs/tags/')
+      #   with:
+      #     files: ${{ steps.build-binary.outputs.OUTPUT_FILES }}

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -42,9 +42,9 @@ jobs:
           head plugin.cfg
       - name: Test everything works well
         run: |
-          ls -lsh coredns
-          ls -lsh coredns/plugin
-          ls -lsh coredns/plugin/blocker/
+          ls -lsh .
+          ls -lsh ./plugin
+          ls -lsh ./plugin/blocker/
       # Caching is enabled by default when using setup-go
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -2,9 +2,8 @@ name: Build Binary
 
 on:
   push:
-    # Enable after development is completed.
-    # tags:
-    #   - v*
+    tags:
+      - v*
 
 jobs:
   build:

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -16,7 +16,6 @@ jobs:
         go-version: [ '1.22.5' ]
         os-flavor: [ 'linux' ]
         architecture: [ 'amd64', 'arm', 'arm64' ]
-        path-to-build: [ './cmd/email-random' ]
 
     steps:
       # You can test your matrix by printing the current Go version
@@ -50,43 +49,39 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Generate plugin configuration based things and make binary
+      - name: Build binary of CoreDNS
+        id: build-binary
         run: |
-          OUTPUT_FILE_NAME="./$(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }}"
+          echo "Ref: ${{ github.ref }}; Commit: $GITHUB_SHA"
+
+          OUTPUT_FILE_NAME="./coredns-${{ matrix.os-flavor }}-${{ matrix.architecture }}"
+
           go generate
-          make BINARY=$OUTPUT_FILE_NAME
+
+          GOOS=${{ matrix.os-flavor }} GOARCH=${{ matrix.architecture }} CGO_ENABLED=0 \
+            go build -v \
+            -ldflags="-s -w -X \"github.com/coredns/coredns/coremain.GitCommit=Blocker plugin ${{ github.ref }} $GITHUB_SHA\"" \
+            -o $OUTPUT_FILE_NAME
+
+          sha256sum $OUTPUT_FILE_NAME > $OUTPUT_FILE_NAME.checksum
+
           file ./$OUTPUT_FILE_NAME
-      # - name: Build binary for the given paths
-      #   id: build-binary
-      #   run: |
-      #     echo "Ref: ${{ github.ref }}; Commit: $GITHUB_SHA"
+          file ./$OUTPUT_FILE_NAME.checksum
 
-      #     OUTPUT_FILE_NAME="./$(basename ${{ matrix.path-to-build }})-${{ matrix.os-flavor }}-${{ matrix.architecture }}"
+          chmod 755 ./$OUTPUT_FILE_NAME
+          chmod 644 ./$OUTPUT_FILE_NAME.checksum
 
-      #     GOOS=${{ matrix.os-flavor }} GOARCH=${{ matrix.architecture }} \
-      #       go build \
-      #       -ldflags="-X \"github.com/icyflame/kindle-my-clippings-parser/internal/env.Version=${{ github.ref }} $GITHUB_SHA\"" \
-      #       -o $OUTPUT_FILE_NAME ${{ matrix.path-to-build }}
+          tar --create --gzip --file ./$OUTPUT_FILE_NAME.tar.gz ./$OUTPUT_FILE_NAME ./$OUTPUT_FILE_NAME.checksum
 
-      #     sha256sum $OUTPUT_FILE_NAME > $OUTPUT_FILE_NAME.checksum
+          ls -lsh .
 
-      #     file ./$OUTPUT_FILE_NAME
-      #     file ./$OUTPUT_FILE_NAME.checksum
-
-      #     chmod 755 ./$OUTPUT_FILE_NAME
-      #     chmod 644 ./$OUTPUT_FILE_NAME.checksum
-
-      #     tar --create --gzip --file ./$OUTPUT_FILE_NAME.tar.gz ./$OUTPUT_FILE_NAME ./$OUTPUT_FILE_NAME.checksum
-
-      #     ls -lsh .
-
-      #     {
-      #         echo 'OUTPUT_FILES<<EOF'
-      #         echo $OUTPUT_FILE_NAME.tar.gz
-      #         echo EOF
-      #     } >> "$GITHUB_OUTPUT"
-      # - name: Upload binaries if a tag was pushed
-      #   uses: softprops/action-gh-release@v2
-      #   if: startsWith(github.ref, 'refs/tags/')
-      #   with:
-      #     files: ${{ steps.build-binary.outputs.OUTPUT_FILES }}
+          {
+              echo 'OUTPUT_FILES<<EOF'
+              echo $OUTPUT_FILE_NAME.tar.gz
+              echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - name: Upload binaries if a tag was pushed
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: ${{ steps.build-binary.outputs.OUTPUT_FILES }}

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -18,32 +18,20 @@ jobs:
         architecture: [ 'amd64', 'arm', 'arm64' ]
 
     steps:
-      # You can test your matrix by printing the current Go version
-      - name: Display Go version
-        run: go version
-      # Fetch the coredns repository first
+      # Fetch the coredns repository first. This is expanded at ./
       - name: Fetch the coredns repository at a tag
         uses: actions/checkout@v4
         with:
           repository: 'coredns/coredns'
           ref: 'v1.11.1'
-      # Fetch this repository first
+      # Fetch this repository next. It is put inside ./plugin/blocker/
       - name: Fetch the present repository
         uses: actions/checkout@v4
         with:
           path: './plugin/blocker'
-      - name: Move plugin.cfg to the top level
+      - name: Move plugin.cfg from blocker plugin to the top level (coredns level)
         run: |
-          ls -lsh plugin.cfg
-          head plugin.cfg
           mv ./plugin/blocker/plugin.cfg ./plugin.cfg
-          ls -lsh plugin.cfg
-          head plugin.cfg
-      - name: Test everything works well
-        run: |
-          ls -lsh .
-          ls -lsh ./plugin
-          ls -lsh ./plugin/blocker/
       # Caching is enabled by default when using setup-go
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v5
@@ -54,24 +42,24 @@ jobs:
         run: |
           echo "Ref: ${{ github.ref }}; Commit: $GITHUB_SHA"
 
-          OUTPUT_FILE_NAME="./coredns-${{ matrix.os-flavor }}-${{ matrix.architecture }}"
+          OUTPUT_FILE_NAME="coredns-${{ matrix.os-flavor }}-${{ matrix.architecture }}"
 
           go generate
 
           GOOS=${{ matrix.os-flavor }} GOARCH=${{ matrix.architecture }} CGO_ENABLED=0 \
-            go build -v \
+            go build \
             -ldflags="-s -w -X \"github.com/coredns/coredns/coremain.GitCommit=Blocker plugin ${{ github.ref }} $GITHUB_SHA\"" \
             -o $OUTPUT_FILE_NAME
 
           sha256sum $OUTPUT_FILE_NAME > $OUTPUT_FILE_NAME.checksum
 
-          file ./$OUTPUT_FILE_NAME
-          file ./$OUTPUT_FILE_NAME.checksum
+          file $OUTPUT_FILE_NAME
+          file $OUTPUT_FILE_NAME.checksum
 
-          chmod 755 ./$OUTPUT_FILE_NAME
-          chmod 644 ./$OUTPUT_FILE_NAME.checksum
+          chmod 755 $OUTPUT_FILE_NAME
+          chmod 644 $OUTPUT_FILE_NAME.checksum
 
-          tar --create --gzip --file ./$OUTPUT_FILE_NAME.tar.gz ./$OUTPUT_FILE_NAME ./$OUTPUT_FILE_NAME.checksum
+          tar --create --gzip --file $OUTPUT_FILE_NAME.tar.gz $OUTPUT_FILE_NAME $OUTPUT_FILE_NAME.checksum
 
           ls -lsh .
 

--- a/plugin.cfg
+++ b/plugin.cfg
@@ -1,0 +1,10 @@
+# This file defines the order in which plugins are executed for an incoming request.
+# The order of plugins in the Corefile is immaterial.
+# Reference: https://coredns.io/2017/06/08/how-queries-are-processed-in-coredns/
+# Order of plugin execution is from top to bottom.
+metadata:metadata
+prometheus:metrics
+log:log
+any:any
+blocker:blocker
+forward:forward


### PR DESCRIPTION
Similar to https://github.com/icyflame/kindle-my-clippings-parser/pull/1, I want to stop building CoreDNS locally. It requires the correct structure of repositories, and also requires a `plugin.cfg` file which was maintained in a separate repository until now.

With this PR, the repository will start uploading release `tar.gz` files which will contain binary files and checksum files for multiple OSes and architectures.